### PR TITLE
return object so method can be chained in builder

### DIFF
--- a/lib/FFIMe.php
+++ b/lib/FFIMe.php
@@ -118,6 +118,7 @@ class FFIMe {
 
     public function showWarnings(bool $show) {
         $this->showWarnings = $show;
+        return $this;
     }
     
     public function warning(string $message) {


### PR DESCRIPTION
#17 should have included this, my mistake!

Enables method chaining to be used like so:
```php
(new FFIMe\FFIMe("libextism.".soext()))
                ->include("extism.h")
                ->showWarnings(false)
                ->codeGen('Extism', 'Extism.php');
```